### PR TITLE
fix: adding color entry for task entity

### DIFF
--- a/scss/mixins.scss
+++ b/scss/mixins.scss
@@ -18,7 +18,7 @@ $entityColors: (
   "sendout": $color-sendout,
   "placement": $color-placement,
   "note": $color-note,
-  "task": $color-neutral,
+  "task": $color-task,
   "distributionList": $color-neutral,
   "credential": $color-neutral,
   "user": $color-neutral,

--- a/src/tokens/color/entity.js
+++ b/src/tokens/color/entity.js
@@ -13,6 +13,7 @@ module.exports = {
   placement: "#0b344f",
   note: "#747884",
   contract: "#454ea0",
+  task: "#4f5361",
   jobCode: "#696d79",
   earnCode: "#696d79",
   invoiceStatement: "#696d79",


### PR DESCRIPTION
task was previously set to the neutral color in mixins.scss, but didn't have its own entry in entity.js which is used to generate the $color-variables in variables.scss. adding a task entry set to the neutral color hex code fixed this, so now 'task' can be used as an entity variable when setting accent/theme etc colors.