### PR TITLE
feat(ESM): Add ESM export support to novo-design-tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "license": "MIT",
   "main": "lib/variables.js",
   "module": "lib/variables.esm.js",
+  "exports": {
+    ".": {
+      "import": "./lib/variables.esm.js",
+      "require": "./lib/variables.js",
+      "default": "./lib/variables.js"
+    }
+  },
   "files": [
     "lib",
     "css",


### PR DESCRIPTION
Add dual export configuration to support both ESM and CommonJS consumers:
- ESM imports now resolve to lib/variables.esm.js (named exports)
- CommonJS requires continue to use lib/variables.js
- Maintains backward compatibility with existing CommonJS consumers

This enables novo-elements and downstream projects to use Vitest and other modern ESM-based test runners without module resolution errors.